### PR TITLE
Launcher: Reimplement xdg-terminal-exec for Linux terminal

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -209,6 +209,11 @@ def launch(exe: Sequence[str], in_terminal: bool = False) -> bool:
             subprocess.Popen(["start", f"Running {apname}", *exe], shell=True)
             return True
         elif is_linux:
+            # Attempt to use xdg-terminal-exec first to allow user-defined defaults
+            xdg = which('xdg-terminal-exec')
+            if xdg:
+                subprocess.Popen([xdg, '--', *exe])
+                return True
             terminal = which('x-terminal-emulator') or which("konsole") or which('gnome-terminal') or which('xterm')
             if terminal:
                 # Clear LD_LIB_PATH during terminal startup, but set it again when running command in case it's needed


### PR DESCRIPTION
Re-add support for xdg-terminal-exec in Linux terminal launch

## What is this fixing or adding?
This was previously added in #16 but appears to have been dropped with the sync to upstream in 1705620c4f37e86b8414aa3bf70d4fdd1ed29ded.

## How was this tested?
Same was as before.