### PR TITLE
Per slot collect perms

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -308,6 +308,9 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
                         elif any([location.item.name in multiworld.worlds[player].options.start_hints
                                   for player in multiworld.groups.get(location.item.player, {}).get("players", [])]):
                             precollect_hint(location, auto_status)
+                
+                allow_collecting_from: dict[int, bool] = {player: multiworld.worlds[player].options.allow_collecting_from.value != 0
+                                                     for player in multiworld.player_ids}
 
                 # embedded data package
                 data_package = {
@@ -345,6 +348,7 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
                     "spheres": spheres,
                     "datapackage": data_package,
                     "race_mode": int(multiworld.is_race),
+                    "allow_collecting_from": allow_collecting_from
                 }
                 # TODO: change to `"version": version_tuple` after getting better serialization
                 AutoWorld.call_all(multiworld, "modify_multidata", multidata)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1138,8 +1138,16 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
         # Trim failed worlds from the list so they aren't collected
         for failed in failed_collects:
             all_locations.pop(failed)
-        failed_worlds = ", ".join((ctx.player_names[(team, failed)] for failed in sorted(failed_collects)))
-        failed_worlds = f"[{failed_worlds}] which {'have' if len(failed_collects) > 1 else 'has'} collecting disabled"
+        failed_names = [ctx.player_names[(team, failed)] for failed in sorted(failed_collects)]
+        fail_count = len(failed_names)
+        max_fail_count = 5
+        if fail_count > max_fail_count:
+            failed_worlds = ", ".join(failed_names[:max_fail_count])
+            failed_worlds += f", +{fail_count - max_fail_count} more"
+        else:
+            failed_worlds = ", ".join(failed_names)
+
+        failed_worlds = f"[{failed_worlds}] which {'have' if fail_count > 1 else 'has'} collecting disabled"
         if not all_locations:  # all collection failed
             collect_str = f"failed to collect their items from {failed_worlds}."
         else:  # some collection succeeded

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1122,12 +1122,34 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
     """register any locations that are in the multidata, pointing towards this player"""
     all_locations = ctx.locations.get_for_player(slot)
 
-    ctx.broadcast_text_all("%s (Team #%d) has collected their items from other worlds."
-                           % (ctx.player_names[(team, slot)], team + 1),
-                           {"type": "Collect", "team": team, "slot": slot})
+    failed_collects = set()  # track what worlds have collecting turned off
+    empty_worlds = set()  # track empty worlds to not bother with them / calculate more accurate message
     for source_player, location_ids in all_locations.items():
         if not ctx.can_collect_from(team, source_player):
-            continue
+            failed_collects.add(source_player)
+        elif not (location_ids - ctx.location_checks[team, source_player]):
+            empty_worlds.add(source_player)
+
+    for empty in empty_worlds:  # trim empty worlds as there's nothing to collect from them
+        all_locations.pop(empty)
+
+    collect_str = "has collected their items from all other worlds."
+    if failed_collects:
+        # Trim failed worlds from the list so they aren't collected
+        for failed in failed_collects:
+            all_locations.pop(failed)
+        failed_worlds = ", ".join((ctx.player_names[(team, failed)] for failed in sorted(failed_collects)))
+        if not all_locations:  # all collection failed
+            collect_str = f"failed to collect their items from [{failed_worlds}]."
+        else:  # some collection succeeded
+            collect_str = f"has collected their items from worlds except [{failed_worlds}]."
+    elif not all_locations:  # no collection left to be done
+        collect_str = "has no items left to collect."
+
+    ctx.broadcast_text_all("%s (Team #%d) %s"
+                           % (ctx.player_names[(team, slot)], team + 1, collect_str),
+                           {"type": "Collect", "team": team, "slot": slot})
+    for source_player, location_ids in all_locations.items():
         register_location_checks(ctx, team, source_player, location_ids, count_activity=False)
         update_checked_locations(ctx, team, source_player)
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1886,6 +1886,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
         return self.get_hints(" ".join(location_name), True, int(amount))
 
     def _cmd_collect_from(self, should_allow: str = ""):
+        """Check or change the permission of other worlds to collect items from your world."""
         if should_allow == "":
             can_collect = self.ctx.can_collect_from(self.client.team, self.client.slot)
             self.output(f"You currently {'can' if can_collect else 'cannot'} be collected from."
@@ -1895,8 +1896,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
         allow_collect: bool
         if should_allow in ("allow", "true", "on", "yes"):
             allow_collect = True
+            self.output("You can now be collected from.")
         elif should_allow in ("deny", "false", "off", "no"):
             allow_collect = False
+            self.output("You can no longer be collected from.")
         else:
             self.output(f"Invalid argument '{should_allow}', valid args are 'allow', 'deny', or no argument.")
             return

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1125,10 +1125,10 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
     failed_collects = set()  # track what worlds have collecting turned off
     empty_worlds = set()  # track empty worlds to not bother with them / calculate more accurate message
     for source_player, location_ids in all_locations.items():
-        if not ctx.can_collect_from(team, source_player):
-            failed_collects.add(source_player)
-        elif not (location_ids - ctx.location_checks[team, source_player]):
+        if not (location_ids - ctx.location_checks[team, source_player]):
             empty_worlds.add(source_player)
+        elif not ctx.can_collect_from(team, source_player):
+            failed_collects.add(source_player)
 
     for empty in empty_worlds:  # trim empty worlds as there's nothing to collect from them
         all_locations.pop(empty)
@@ -1139,10 +1139,11 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
         for failed in failed_collects:
             all_locations.pop(failed)
         failed_worlds = ", ".join((ctx.player_names[(team, failed)] for failed in sorted(failed_collects)))
+        failed_worlds = f"[{failed_worlds}] which {'have' if len(failed_collects) > 1 else 'has'} collecting disabled"
         if not all_locations:  # all collection failed
-            collect_str = f"failed to collect their items from [{failed_worlds}]."
+            collect_str = f"failed to collect their items from {failed_worlds}."
         else:  # some collection succeeded
-            collect_str = f"has collected their items from worlds except [{failed_worlds}]."
+            collect_str = f"has collected their items from worlds except {failed_worlds}."
     elif not all_locations:  # no collection left to be done
         collect_str = "has no items left to collect."
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -249,6 +249,8 @@ class Context:
     all_item_and_group_names: typing.Dict[str, typing.Set[str]]
     all_location_and_group_names: typing.Dict[str, typing.Set[str]]
     non_hintable_names: typing.Dict[str, typing.AbstractSet[str]]
+    def_allow_collecting_from: dict[int, bool]  # per slot, the starting collect_from value
+    allow_collecting_from: dict[int, dict[int, bool]]  # per team, the current collect_from value
     spheres: typing.List[typing.Dict[int, typing.Set[int]]]
     """ each sphere is { player: { location_id, ... } } """
     logger: logging.Logger
@@ -272,6 +274,8 @@ class Context:
         self.player_name_lookup: typing.Dict[str, team_slot] = {}
         self.connect_names = {}  # names of slots clients can connect to
         self.allow_releases = {}
+        self.def_allow_collecting_from = {}
+        self.allow_collecting_from = {}
         self.host = host
         self.port = port
         self.server_password = server_password
@@ -525,6 +529,8 @@ class Context:
         self.clients = {0: {}}
         slot_info: NetworkSlot
         slot_id: int
+
+        self.def_allow_collecting_from = decoded_obj.get("allow_collecting_from", {})
 
         team_0 = self.clients[0]
         for slot_id, slot_info in self.slot_info.items():
@@ -893,6 +899,10 @@ class Context:
         if targets:
             self.broadcast(targets, [{"cmd": "SetReply", "key": key, "value": self.client_game_state[team, slot]}])
 
+    def can_collect_from(self, team: int, slot: int) -> bool:
+        return (self.allow_collecting_from.get(team, {})
+                .get(slot, self.def_allow_collecting_from.get(slot, True)))
+
 
 def update_aliases(ctx: Context, team: int):
     cmd = ctx.dumper([{"cmd": "RoomUpdate",
@@ -1116,6 +1126,8 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
                            % (ctx.player_names[(team, slot)], team + 1),
                            {"type": "Collect", "team": team, "slot": slot})
     for source_player, location_ids in all_locations.items():
+        if not ctx.can_collect_from(team, source_player):
+            continue
         register_location_checks(ctx, team, source_player, location_ids, count_activity=False)
         update_checked_locations(ctx, team, source_player)
 
@@ -1872,6 +1884,25 @@ class ClientMessageProcessor(CommonCommandProcessor):
         """For example, '!hint_location_multiple 5 Everywhere' to get a spoiler peek for matching locations.
         Will return as many results as possible up to the specified amount, possibly spending multiple hints worth of hint points in the process."""
         return self.get_hints(" ".join(location_name), True, int(amount))
+
+    def _cmd_collect_from(self, should_allow: str = ""):
+        if should_allow == "":
+            can_collect = self.ctx.can_collect_from(self.client.team, self.client.slot)
+            self.output(f"You currently {'can' if can_collect else 'cannot'} be collected from."
+                        f" Use '!collect_from {'deny' if can_collect else 'allow'}' to change this.")
+            return
+        should_allow = should_allow.lower()
+        allow_collect: bool
+        if should_allow in ("allow", "true", "on", "yes"):
+            allow_collect = True
+        elif should_allow in ("deny", "false", "off", "no"):
+            allow_collect = False
+        else:
+            self.output(f"Invalid argument '{should_allow}', valid args are 'allow', 'deny', or no argument.")
+            return
+        if self.client.team not in self.ctx.allow_collecting_from:
+            self.ctx.allow_collecting_from[self.client.team] = {}
+        self.ctx.allow_collecting_from[self.client.team][self.client.slot] = allow_collect
 
 
 def get_checked_checks(ctx: Context, team: int, slot: int) -> typing.List[int]:

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -540,6 +540,7 @@ class MultiData(typing.TypedDict):
     spheres: list[dict[int, set[int]]]
     datapackage: dict[str, GamesPackage]
     race_mode: int
+    allow_collecting_from: dict[int, bool]
 
 
 if typing.TYPE_CHECKING:  # type-check with pure python implementation until we have a typing stub

--- a/Options.py
+++ b/Options.py
@@ -1521,6 +1521,12 @@ class DeathLink(Toggle):
     rich_text_doc = True
 
 
+class AllowCollectingFrom(DefaultOnToggle):
+    """If other players are allowed to '!collect' items from your world."""
+    display_name = "Allow Collecting"
+    rich_text_doc = True
+
+
 class ItemLinks(OptionList):
     """Share part of your item pool with other players."""
     display_name = "Item Links"
@@ -1744,6 +1750,7 @@ class PerGameCommonOptions(CommonOptions):
     priority_locations: PriorityLocations
     item_links: ItemLinks
     plando_items: PlandoItems
+    allow_collecting_from: AllowCollectingFrom
 
 
 @dataclass


### PR DESCRIPTION
## What is this fixing or adding?
- Each slot can now determine if `!collect` / `/collect` can collect items from their slot.
- A new `PerGameCommonOptions` yaml setting is added- `allow_collecting_from`, a `DefaultOnToggle`.
- A new client command is added, `!collect_from`. Running without arguments tells you your current collect_from status, and giving an argument of `allow`/`true`/`on`/`yes` or `deny`/`false`/`off`/`no` will change the permission respectively.
- The code for `!collect` has been entirely revamped. It now trims "empty" location lists (worlds which had items for you, but all their items for you are already collected), and then trims out worlds that have disabled collecting from them. The message broadcasted when the command is used is changed accordingly:
  -  `[name/team] failed to collect their items from [worlds] which have collecting disabled.`, if no items were collected, but items remain in worlds that cannot be collected from.
  -  `[name/team] has collected their items from worlds except [worlds] which have collecting disabled.`, if some items were collected, but items remain in worlds that cannot be collected from.
  -  `[name/team] has collected their items from all other worlds.` if at least 1 item was collected, and no items remain to be collected.
  -  `[name/team] has no items left to collect.` if no items were collected, because they were already all collected.
  - For the messages that say `[worlds]`, it will list the slots that collect tried and failed to collect from, up to a maximum of 5- if more than 5 such worlds exist, it will add `, +X more` after the first 5 world names, where X is the number of worlds not displayed.

## How was this tested?
testing/discussion occurred in this thread: https://discord.com/channels/1345801058609270794/1508597249821770009
a local webhost was hosted, and in a local room of 8 BK Simulators, half starting with collect disabled via yaml, were used. `!collect` was run under various circumstances to ensure the correct items were collected, and the correct messages displayed. `!collect_from` was also used to toggle the permission on/off and then `!collect` was tested again to ensure it worked properly.
While this was NOT tested with Silvris' `teams` PR, the code should correctly handle teams in every way.

This adds new data to the multidata, so I also tested using an MWGG generated world on archipelago.gg's hosting to be sure it was compatible- there were no issues.
This adds a new PerGameCommonOption, so I also tested using an MWGG created yaml on core AP's (local) generation - the new option was ignored and did not cause generator errors. (Obviously there's no way to make Core actually obey the option 😅)

I did have some severe issues getting testing anything to work to start with, but those appeared to be python package issues caused by `dk64` and `albw` worlds- the issues caused by that were breaking several things that were NOT added in this PR, so I don't believe it to be related to this PR. Those issues were solved for testing by deleting those worlds locally 😅 may want to take a separate look into what's causing that. (the errors I believe mentioned `PIL` and `requests` packages, and were breaking many things already on the `main` branch)

## If this makes graphical changes, please attach screenshots.
<img width="628" height="207" alt="image" src="https://github.com/user-attachments/assets/59626f7b-010e-496d-9f90-b84d47b561a5" />
<img width="867" height="67" alt="image" src="https://github.com/user-attachments/assets/97df949f-8419-4e25-9285-b15a48994506" />
With the limit of 5 worlds temporarily lowered to 2 worlds to test the text cutoff:
<img width="1099" height="69" alt="image" src="https://github.com/user-attachments/assets/f4152861-b8dc-4651-bd09-cb750fc206f6" />
With the limit of 5 worlds temporarily lowered to 1 world to test the text cutoff:
<img width="957" height="73" alt="image" src="https://github.com/user-attachments/assets/0ef9cbc9-96ab-461f-8ee7-92913413886f" />
Before `have`/`has` grammar was fixed (this message should say `has` now, as tested in an image above):
<img width="1010" height="141" alt="image" src="https://github.com/user-attachments/assets/9ce2a807-6f51-4ec3-a096-6b944022c18c" />
