### PR TITLE
Save the collect_from status to allow it to persist reloads.

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -691,7 +691,8 @@ class Context:
                              "remaining_mode": self.remaining_mode, "collect_mode": self.collect_mode,
                              "countdown_mode": self.countdown_mode, "hint_mode": self.hint_mode, 
                              "release_threshold": self.release_threshold, "item_cheat": self.item_cheat, 
-                             "compatibility": self.compatibility}
+                             "compatibility": self.compatibility},
+            "allow_collecting_from": self.allow_collecting_from
 
         }
 
@@ -739,6 +740,9 @@ class Context:
 
         if "stored_data" in savedata:
             self.stored_data = savedata["stored_data"]
+
+        if "allow_collecting_from" in savedata:
+            self.allow_collecting_from = savedata["allow_collecting_from"]
         # count items and slots from lists for items_handling = remote
         self.logger.info(
             f'Loaded save file with {sum([len(v) for k, v in self.received_items.items() if k[2]])} received items '


### PR DESCRIPTION
## What is this fixing or adding?
#25 introduced the ability to allow players to opt-out of being collected from with a yaml option or a command. This was great and it was *the* reason that I moved a community async to mwgg hosting. However, usages of the command were not saved, and did not persist across a server restart. This led to unexpected collecting that was thought to be forbidden, and that led me to file #29 (and to disable collects on that async until this is fixed).

This PR fixes #29 by saving the state of collections with other savedata.

## How was this tested?
I self-hosted a multiworld through `MultiServer.py` and connected to it with a few text clients, checking `!collect_from` status and changing it and restarting the server a few times.

## If this makes graphical changes, please attach screenshots.
It does not.