### PR TITLE
Revise landing page third-party tools section

### DIFF
--- a/WebHostLib/templates/landing.html
+++ b/WebHostLib/templates/landing.html
@@ -38,7 +38,11 @@
                 </p>
                 <p>
                     This project is based on <a href="https://github.com/ArchipelagoMW/Archipelago">Archipelago</a>, a cumulative effort of many
-                    <a href="https://github.com/ArchipelagoMW/Archipelago/graphs/contributors">talented people.</a><br />We also link to or include a few amazing third party open source clients and tracking tools created by amazing contributors, like the <a href="https://cheesetrackers.theincrediblewheelofchee.se/">Cheese Trackers</a> by <a href="https://github.com/cdhowie/cheese-trackers">Cheese</a>, the <a href="https://drawesome4333.github.io/ap-tracker/">AP checklist tracker</a> by <a href="https://github.com/DrAwesome4333/ap-tracker">DrAwesome4333</a>, the <a href="https://archipelago.miraheze.org/wiki/Main_Page">AP Wiki</a>  maintained by Flit, Rooby, and others, or the <a href="https://ap-lobby.bananium.fr/">Bananium AP Lobby</a> by <a href="https://github.com/Eijebong/Archipelago-lobby">Eijebong</a>, who inspired our current lobby system.
+                    <a href="https://github.com/ArchipelagoMW/Archipelago/graphs/contributors">talented people.</a><br />We also link to or 
+                    include a few amazing third party open source clients and tracking tools created by amazing contributors, like the 
+                    <a href="https://cheesetrackers.theincrediblewheelofchee.se/">Cheese Trackers</a> by <a href="https://github.com/cdhowie/cheese-trackers">Cheese</a>,
+                    the <a href="https://drawesome4333.github.io/ap-tracker/">AP checklist tracker</a> by <a href="https://github.com/DrAwesome4333/ap-tracker">DrAwesome4333</a>,
+                    and the community-run <a href="https://archipelago.miraheze.org/wiki/Main_Page">AP Wiki</a>.
                 <p>
                     Multiworld.GG is a fork, incorporating many tweaks and additional worlds of many 3rd party developers
                     that cannot be part of the original project. We also offer worlds that are still in earlier stages of development.


### PR DESCRIPTION
Two primary changes:
1) Change the wiki language to not specify the names of some of the wiki admins. This project is much larger than myself, and I feel weird having my name on it when it is 1000% a community collaboration. I don't imagine Flit feels too differently on the matter. Or, at least, if we DO name us, we should at least name the other admins as well? idk.
2) Remove the link to (and mention of) the discontinued Bananium tool. If you wanna honor the project somehow, maybe put it further down in the README which credits adjacent projects? Legacy aside, I don't think a link to a "we're closed and Archipelago sucks" page is a good idea.

I also threw in some line breaks for readability. It's been 100 years since I last touched HTML, so please actually verify that those linebreaks don't ruin anything, I'm not sure how to check and I haven't run this locally.