### PR TITLE
Webhost: "Unofficial Wiki">"Community Wiki"

### DIFF
--- a/WebHostLib/templates/header/baseHeader.html
+++ b/WebHostLib/templates/header/baseHeader.html
@@ -32,7 +32,7 @@
                 <a href="https://drawesome4333.github.io/ap-tracker/" target="_blank">Checklist Tracker</a>
                 <a href="https://cheesetrackers.theincrediblewheelofchee.se" target="_blank">Cheesetrackers</a>
                 <a href="https://manual.multiworld.gg" target="_blank">Manual World Client</a>
-                <a href="https://archipelago.miraheze.org/wiki/Category:Games" target="_blank">Unofficial Wiki</a>
+                <a href="https://archipelago.miraheze.org/wiki/Category:Games" target="_blank">Community Wiki</a>
             </div>
             <a href="/downloads">Downloads</a>
             <a href="https://discord.multiworld.gg" target="_blank">Discord</a>


### PR DESCRIPTION
The term "unofficial" is an insistence that we have in order to keep in good graces with AP main. You don't have this issue, so it doesn't apply here.

I prefer this terminology. let me know what you think.