### PR TITLE
Universal Tracker: Hint Tab Sorting / Filters

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -551,6 +551,101 @@ class MarkupDropdown(MDDropdownMenu):
             self.menu.data = self._items
 
 
+class ToggleDropdownItem(RecycleDataViewBehavior, MDBoxLayout):
+    text = StringProperty("")
+    active = BooleanProperty(False)
+    padding_x = NumericProperty(dp(15))
+    index = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.toggle_text = MDButtonText(self.text, size_hint_x=1, size_hint_y=None)
+        self.toggle = ToggleButton(self.toggle_text, theme_width="Custom", size_hint_x=1,
+                                   radius=[dp(0),dp(0),dp(0),dp(0)])
+
+        self.padding = [0]
+        self.toggle_text.padding = [0]
+
+        def update_text(instance, value):
+            instance.toggle_text.text = value
+
+        def update_padding(instance, value):
+            instance.toggle._text_right_pad = value
+            instance.toggle._text_left_pad = value
+        self.bind(padding_x=update_padding)
+        self.bind(text=update_text)
+        update_padding(self, self.padding_x)
+        update_text(self, self.text)
+        self.toggle.bind(state=self._on_toggle)
+        self.rv = None
+        self.add_widget(self.toggle)
+
+    def refresh_view_attrs(self, rv, index, data):
+        self.index = index
+        self.rv = rv
+        self.text = data.get("text", "")
+        self.toggle.state = "down" if data.get("active") else "normal"
+        return super().refresh_view_attrs(rv, index, data)
+
+    def _on_toggle(self, toggle, new_state):
+        self.active = new_state == "down"
+        if self.rv is not None and self.index is not None:
+            self.rv.data[self.index]["active"] = self.active
+
+
+Factory.register("ToggleDropdownItem", ToggleDropdownItem)
+
+
+class ToggleDropdown(MDDropdownMenu):
+    def open(self) -> None:
+        self.set_menu_properties()
+        Window.add_widget(self)
+        self.position = self.adjust_position()
+        
+        # Create dummy items for layout calculation to determine dropdown width
+        width_calculated = dp(20)
+        for item in self.items:
+            viewclass = Factory.get(item.get("viewclass", "ToggleDropdownItem"))
+            kwargs = {}
+            kwargs.update(item)
+            kwargs.pop("viewclass")
+            temp = viewclass(**kwargs)
+            temp.size_hint_x = None
+            temp.width = dp(1000)
+            if isinstance(temp, ToggleDropdownItem):
+                temp.toggle_text.texture_update()
+                temp.toggle.theme_width = "Primary"
+                temp.toggle.adjust_width()
+
+            temp.do_layout()
+
+            width_calculated = max(width_calculated, temp.minimum_width)
+
+        self.width = width_calculated
+
+        self.height = self.target_height
+        self._tar_x, self._tar_y = self.get_target_pos()
+        self.x = self._tar_x
+        self.y = self._tar_y - self.target_height
+        self.scale_value_center = self.caller.center
+        self.set_menu_pos()
+        self.on_open()
+
+    def on_items(self, instance, value: list) -> None:
+        items = []
+
+        for data in value:
+            if "viewclass" not in data:
+                data["viewclass"] = "ToggleDropdownItem"
+
+            items.append(data)
+
+        self._items = items
+        # Update items in view
+        if hasattr(self, "menu"):
+            self.menu.data = self._items
+
+
 class AutocompleteHintInput(ResizableTextField):
     min_chars = NumericProperty(3)
 
@@ -692,7 +787,13 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
             # find correct column
             for child in self.children:
                 if child.collide_point(*touch.pos):
-                    if parent.sort_by_key(child.sort_key):
+                    if touch.button == 'right':
+                        for key,val in self.ids.items():
+                            if val == child:
+                                parent.pop_filter_dropdown_for(key, parent.data[1:], child, MDApp.get_running_app().update_hints)
+                                return True
+                        return False
+                    elif parent.sort_by_key(child.sort_key):
                         MDApp.get_running_app().update_hints()
                         return True
                     return False
@@ -1254,7 +1355,8 @@ class ColumnSorter:
 class ColumnSortMixin:
     column_sorters: list[ColumnSorter]
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.column_sorters = []
 
     def sort_by_key(self, key: str) -> bool:
@@ -1277,7 +1379,112 @@ class ColumnSortMixin:
             sorter.sort(data)
 
 
-class HintLog(MDRecycleView, ColumnSortMixin):
+class ColumnFilter:
+    key: str  # Which column key this filter belongs to
+    str_conv_func: typing.Callable[[typing.Any], str | None] | None  # How to turn the data into simple strings
+    filter_denylist: set[str]  # Strings to disallow / hide
+    filter_allowlist: set[str]  # Strings to allow. If non-empty, disallows all not in this list.
+    option_list: set[str]  # Strings to show, whether they are currently in the data or not
+
+    def __init__(self, key: str, conv_func: typing.Callable[[typing.Any], str | None] | None = None):
+        self.key = key
+        self.str_conv_func = conv_func
+        self.filter_denylist = set()
+        self.filter_allowlist = set()
+        self.option_list = set()
+
+    def filter_str(self, value: str) -> bool:
+        if self.filter_allowlist and value not in self.filter_allowlist:
+            return False
+        if value in self.filter_denylist:
+            return False
+        return True
+
+    def filter_data(self, value: typing.Any) -> bool:
+        if self.str_conv_func:
+            value = self.str_conv_func(value)
+        if isinstance(value, str):
+            return self.filter_str(value)
+        return not self.filter_allowlist
+
+    def get_basic_menu_names(self, data: list[typing.Any]) -> list[str]:
+        # Based on denylist
+        shown_values = (self.option_list | self.filter_denylist)
+
+        for value in data:
+            str_value: str
+            if self.str_conv_func:
+                v = self.str_conv_func(value)
+                if v is None:
+                    continue
+                str_value = v
+            elif value is str:
+                str_value = value
+            else:
+                continue
+
+            shown_values.add(str_value)
+
+        return list(sorted(shown_values))
+
+    def build_menu_items(self, data: list[typing.Any]) -> list:
+        menu_items = []
+        for str_value in self.get_basic_menu_names(data):
+            item_data = {
+                "text": str_value,
+                "active": str_value not in self.filter_denylist,
+            }
+
+            item_data["on_dropdown_closed"] = (lambda name=str_value, idat=item_data:
+                                               self.filter_denylist.discard(name) if idat.get("active")
+                                               else self.filter_denylist.add(name))
+
+            menu_items.append(item_data)
+        return menu_items
+
+    def pop_filter_dropdown(self, data: list[typing.Any], caller, after_dropdown_closed: typing.Callable[[], None] | None = None):
+        menu_items = self.build_menu_items(data)
+        if not menu_items:
+            if after_dropdown_closed:
+                after_dropdown_closed()
+            return
+
+        dropdown = ToggleDropdown(caller=caller, items=menu_items, border_margin=0)
+
+        def handle_closing(instance):
+            for item in instance.items:
+                on_closed: typing.Callable[[], None] = item.get("on_dropdown_closed")
+                if on_closed:
+                    on_closed()
+            if after_dropdown_closed:
+                after_dropdown_closed()
+        dropdown.bind(on_dismiss=handle_closing)
+        dropdown.open()
+
+
+class ColumnFilterMixin:
+    column_filters: list[ColumnFilter]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.column_filters = []
+
+    def pop_filter_dropdown_for(self, key: str, data: list[typing.Any], caller, after_dropdown_closed: typing.Callable[[], None] | None = None) -> bool:
+        found_filter: ColumnFilter | None = None
+        for filt in self.column_filters:
+            if filt.key == key:
+                found_filter = filt
+                break
+        if found_filter:
+            found_filter.pop_filter_dropdown(data, caller, after_dropdown_closed)
+            return True
+        return False
+
+    def filter_columns(self, data: list[typing.Any]) -> list[typing.Any]:
+        return [datum for datum in data if all(filt.filter_data(datum) for filt in self.column_filters)]
+
+
+class HintLog(MDRecycleView, ColumnSortMixin, ColumnFilterMixin):
     header = {
         "receiving": {"text": "[u]Receiving Player[/u]"},
         "item": {"text": "[u]Item[/u]"},
@@ -1307,6 +1514,16 @@ class HintLog(MDRecycleView, ColumnSortMixin):
             lambda element: status_sort_weights[element["status"]["hint"]["status"]],
             True
         ))
+
+        # Filter order is irrelevant. Set up basic filters for each column.
+        for key in ["entrance", "receiving", "finding", "item", "location", "status"]:
+            cls = ColumnFilter
+            # TODO: add more advanced filters (ex. item classification)
+            filt = cls(key, lambda element, k=key: remove_between_brackets.sub("", element[k]["text"]))
+            if key == "status":
+                filt.filter_denylist.add(status_names[HintStatus.HINT_FOUND])  # filter out already-found hints by default
+                filt.option_list.update(status_names.values())
+            self.column_filters.append(filt)
 
     def refresh_hints(self, hints):
         if not hints:  # Fix the scrolling looking visually wrong in some edge cases
@@ -1348,6 +1565,7 @@ class HintLog(MDRecycleView, ColumnSortMixin):
                 },
             })
 
+        data = self.filter_columns(data)
         self.sort_columns(data)
 
         for i in range(0, len(data), 2):

--- a/kvui.py
+++ b/kvui.py
@@ -641,8 +641,7 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
             ctx.update_hint(self.hint["location"],
                             self.hint["finding_player"],
                             data)
-
-        self.dropdown.bind(on_release=self.dropdown.dismiss)
+            self.dropdown.dismiss()
 
     def set_height(self, instance, value):
         self.height = max([child.texture_size[1] for child in self.children])

--- a/kvui.py
+++ b/kvui.py
@@ -613,14 +613,16 @@ class ToggleDropdown(MDDropdownMenu):
             kwargs.update(item)
             kwargs.pop("viewclass")
             temp = viewclass(**kwargs)
+            if not hasattr(temp, "minimum_width"):
+                continue
             temp.size_hint_x = None
             temp.width = dp(1000)
             if isinstance(temp, ToggleDropdownItem):
                 temp.toggle_text.texture_update()
                 temp.toggle.theme_width = "Primary"
                 temp.toggle.adjust_width()
-
-            temp.do_layout()
+            if hasattr(temp, "do_layout"):
+                temp.do_layout()
 
             width_calculated = max(width_calculated, temp.minimum_width)
 
@@ -1391,9 +1393,9 @@ class ColumnFilter:
     filter_allowlist: set[str]  # Strings to allow. If non-empty, disallows all not in this list.
     option_list: set[str]  # Strings to show, whether they are currently in the data or not
 
-    def __init__(self, key: str, conv_func: typing.Callable[[typing.Any], str | None] | None = None):
+    def __init__(self, key: str, str_conv_func: typing.Callable[[typing.Any], str | None] | None = None):
         self.key = key
-        self.str_conv_func = conv_func
+        self.str_conv_func = str_conv_func
         self.filter_denylist = set()
         self.filter_allowlist = set()
         self.option_list = set()
@@ -1507,6 +1509,84 @@ class ColumnFilterMixin:
         return [datum for datum in data if all(filt.filter_data(datum) for filt in self.column_filters)]
 
 
+class ColumnFilterItemClassification(ColumnFilter):
+    req_flags: int = 0
+    hide_flags: int = 0
+    hide_filler: bool = False
+    iclass_conv_func: typing.Callable[[typing.Any], int | None] | None  # How to turn the data into item classification
+
+    def __init__(self, key: str, str_conv_func: typing.Callable[[typing.Any], str | None] | None = None,
+                 iclass_conv_func: typing.Callable[[typing.Any], int | None] | None = None):
+        super().__init__(key, str_conv_func)
+        self.iclass_conv_func = iclass_conv_func
+
+    def build_menu_items(self, data: list[typing.Any]) -> list:
+        flags = (
+            ("Progression", 0b001),
+            ("Useful", 0b010),
+            ("Trap", 0b100),
+        )
+        menu_items = []
+        for name, bit in flags:
+            def toggle(val: bool, b=bit) -> None:
+                if val:
+                    self.req_flags |= b
+                else:
+                    self.req_flags &= ~b
+            menu_items.append({
+                "text": f'Req. {name}',
+                "active": (self.req_flags & bit) != 0,
+                "on_toggle": toggle,
+            })
+        for name, bit in flags:
+            def toggle(val: bool, b=bit) -> None:
+                if val:
+                    self.hide_flags |= b
+                else:
+                    self.hide_flags &= ~b
+            menu_items.append({
+                "text": f'Hide {name}',
+                "active": (self.hide_flags & bit) != 0,
+                "on_toggle": toggle,
+            })
+        menu_items.append({
+            "text": "Hide Filler",
+            "active": self.hide_filler,
+            "on_toggle": lambda val: setattr(self, "hide_filler", val)
+        })
+
+        base_menu_items = super().build_menu_items(data)
+        if base_menu_items:
+            menu_items.append({
+                "viewclass": "MDLabel",
+                "text": "----",
+                "size_hint_x": 1,
+                "theme_width": "Custom",
+                "halign": "center",
+            })
+            menu_items.extend(base_menu_items)
+
+        return menu_items
+
+    def filter_classification(self, value: int) -> bool:
+        if self.hide_filler and not value:
+            return False
+        if value & self.req_flags != self.req_flags:
+            return False
+        if value & self.hide_flags != 0:
+            return False
+        return True
+
+    def filter_data(self, value: typing.Any) -> bool:
+        if self.iclass_conv_func:
+            c = self.iclass_conv_func(value)
+            if c is None:
+                c = 0
+            if not self.filter_classification(c):
+                return False
+        return super().filter_data(value)
+
+
 class HintLog(MDRecycleView, ColumnSortMixin, ColumnFilterMixin):
     header = {
         "receiving": {"text": "[u]Receiving Player[/u]"},
@@ -1541,8 +1621,14 @@ class HintLog(MDRecycleView, ColumnSortMixin, ColumnFilterMixin):
         # Filter order is irrelevant. Set up basic filters for each column.
         for key in ["entrance", "receiving", "finding", "item", "location", "status"]:
             cls = ColumnFilter
-            # TODO: add more advanced filters (ex. item classification)
-            filt = cls(key, lambda element, k=key: remove_between_brackets.sub("", element[k]["text"]))
+            kwargs = {
+                "key": key,
+                "str_conv_func": lambda element, k=key: remove_between_brackets.sub("", element[k]["text"]),
+            }
+            if key == "item":
+                cls = ColumnFilterItemClassification
+                kwargs["iclass_conv_func"] = lambda element: element["item"]["flags"]
+            filt = cls(**kwargs)
             if key == "status":
                 filt.filter_denylist.add(status_names[HintStatus.HINT_FOUND])  # filter out already-found hints by default
                 filt.option_list.update(status_names.values())
@@ -1566,12 +1652,15 @@ class HintLog(MDRecycleView, ColumnSortMixin, ColumnFilterMixin):
                 hint_status_node = f"[u]{hint_status_node}[/u]"
             data.append({
                 "receiving": {"text": self.parser.handle_node({"type": "player_id", "text": hint["receiving_player"]})},
-                "item": {"text": self.parser.handle_node({
-                    "type": "item_id",
-                    "text": hint["item"],
-                    "flags": hint["item_flags"],
-                    "player": hint["receiving_player"],
-                })},
+                "item": {
+                    "text": self.parser.handle_node({
+                        "type": "item_id",
+                        "text": hint["item"],
+                        "flags": hint["item_flags"],
+                        "player": hint["receiving_player"],
+                    }),
+                    "flags": hint["item_flags"]
+                },
                 "finding": {"text": self.parser.handle_node({"type": "player_id", "text": hint["finding_player"]})},
                 "location": {"text": self.parser.handle_node({
                     "type": "location_id",

--- a/kvui.py
+++ b/kvui.py
@@ -254,7 +254,7 @@ MDButton.on_release = on_release
 class HoverBehavior(object):
     """originally from https://stackoverflow.com/a/605348110"""
     hovered = BooleanProperty(False)
-    border_point = ObjectProperty(None)
+    border_point = ObjectProperty(None, allownone=True)
 
     def __init__(self, **kwargs):
         self.register_event_type("on_enter")
@@ -263,27 +263,38 @@ class HoverBehavior(object):
         Window.bind(on_cursor_leave=self.on_cursor_leave)
         super(HoverBehavior, self).__init__(**kwargs)
 
-    def on_mouse_pos(self, window, pos):
-        if not self.get_root_window():
-            return  # Abort if not displayed
+    def _find_top_widget(self, widget, pos):
+        if hasattr(widget, "children"):
+            for child in widget.children:
+                res = self._find_top_widget(child, pos)
+                if res is not None:
+                    return res
+        if hasattr(widget, "collide_point") and hasattr(widget, "to_widget"):
+            if widget.collide_point(*widget.to_widget(*pos)):
+                return widget
+        return None
 
-        # to_widget translates window pos to within widget pos
-        inside = self.collide_point(*self.to_widget(*pos))
-        if self.hovered == inside:
-            return  # We have already done what was needed
+    def set_hovered(self, state, pos):
+        if self.hovered == state:
+            return
+        self.hovered = state
         self.border_point = pos
-        self.hovered = inside
-
-        if inside:
+        if state:
             self.dispatch("on_enter")
         else:
             self.dispatch("on_leave")
 
+    def on_mouse_pos(self, window, pos):
+        root_window = self.get_root_window()
+        if not root_window:
+            return  # Abort if not displayed
+
+        hovered_widget = self._find_top_widget(root_window, pos)
+        self.set_hovered(hovered_widget is self, pos)
+
     def on_cursor_leave(self, *args):
         # if the mouse left the window, it is obviously no longer inside the hover label.
-        self.hovered = BooleanProperty(False)
-        self.border_point = ObjectProperty(None)
-        self.dispatch("on_leave")
+        self.set_hovered(False, None)
 
 
 Factory.register("HoverBehavior", HoverBehavior)

--- a/kvui.py
+++ b/kvui.py
@@ -591,6 +591,9 @@ class ToggleDropdownItem(RecycleDataViewBehavior, MDBoxLayout):
         self.active = new_state == "down"
         if self.rv is not None and self.index is not None:
             self.rv.data[self.index]["active"] = self.active
+            toggle_func: typing.Callable[[bool], None] | None = self.rv.data[self.index].get("on_toggle")
+            if toggle_func:
+                toggle_func(self.active)
 
 
 Factory.register("ToggleDropdownItem", ToggleDropdownItem)
@@ -790,7 +793,9 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
                     if touch.button == 'right':
                         for key,val in self.ids.items():
                             if val == child:
-                                parent.pop_filter_dropdown_for(key, parent.data[1:], child, MDApp.get_running_app().update_hints)
+                                parent.pop_filter_dropdown_for(key, parent.data[1:], child,
+                                                               None,
+                                                               lambda _: MDApp.get_running_app().update_hints())
                                 return True
                         return False
                     elif parent.sort_by_key(child.sort_key):
@@ -1430,34 +1435,49 @@ class ColumnFilter:
     def build_menu_items(self, data: list[typing.Any]) -> list:
         menu_items = []
         for str_value in self.get_basic_menu_names(data):
-            item_data = {
+            def toggle(val: bool, name = str_value) -> None:
+                if val:
+                    self.filter_denylist.discard(name)
+                else:
+                    self.filter_denylist.add(name)
+            menu_items.append({
                 "text": str_value,
                 "active": str_value not in self.filter_denylist,
-            }
-
-            item_data["on_dropdown_closed"] = (lambda name=str_value, idat=item_data:
-                                               self.filter_denylist.discard(name) if idat.get("active")
-                                               else self.filter_denylist.add(name))
-
-            menu_items.append(item_data)
+                "on_toggle": toggle
+            })
         return menu_items
 
-    def pop_filter_dropdown(self, data: list[typing.Any], caller, after_dropdown_closed: typing.Callable[[], None] | None = None):
+    def pop_filter_dropdown(self, data: list[typing.Any], caller,
+                            after_dropdown_closed: typing.Callable[[], None] | None = None,
+                            after_toggle: typing.Callable[[bool], None] | None = None):
         menu_items = self.build_menu_items(data)
         if not menu_items:
             if after_dropdown_closed:
                 after_dropdown_closed()
             return
 
+        if after_toggle:
+            # Add the 'after_toggle' function to every item
+            for item in menu_items:
+                func = item.get("on_toggle")
+                if func is None:
+                    item["on_toggle"] = after_toggle
+                else:
+                    def toggle(val, fn=func):
+                        fn(val)
+                        after_toggle(val)
+                    item["on_toggle"] = toggle
+
         dropdown = ToggleDropdown(caller=caller, items=menu_items, border_margin=0)
 
         def handle_closing(instance):
-            for item in instance.items:
-                on_closed: typing.Callable[[], None] = item.get("on_dropdown_closed")
+            for mitem in instance.items:
+                on_closed: typing.Callable[[], None] = mitem.get("on_dropdown_closed")
                 if on_closed:
                     on_closed()
             if after_dropdown_closed:
                 after_dropdown_closed()
+
         dropdown.bind(on_dismiss=handle_closing)
         dropdown.open()
 
@@ -1469,14 +1489,17 @@ class ColumnFilterMixin:
         super().__init__(**kwargs)
         self.column_filters = []
 
-    def pop_filter_dropdown_for(self, key: str, data: list[typing.Any], caller, after_dropdown_closed: typing.Callable[[], None] | None = None) -> bool:
+    def pop_filter_dropdown_for(self, key: str, data: list[typing.Any], caller,
+                                after_dropdown_closed: typing.Callable[[], None] | None = None,
+                                after_toggle: typing.Callable[[bool], None] | None = None
+                                ) -> bool:
         found_filter: ColumnFilter | None = None
         for filt in self.column_filters:
             if filt.key == key:
                 found_filter = filt
                 break
         if found_filter:
-            found_filter.pop_filter_dropdown(data, caller, after_dropdown_closed)
+            found_filter.pop_filter_dropdown(data, caller, after_dropdown_closed, after_toggle)
             return True
         return False
 

--- a/worlds/tracker/TrackerClient.py
+++ b/worlds/tracker/TrackerClient.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import traceback
 from collections.abc import Callable
+
 from CommonClient import CommonContext, get_base_parser, server_loop, ClientCommandProcessor, handle_url_arg
 import os
 import sys
@@ -16,7 +17,7 @@ from . import TrackerWorld, UTMapTabData, CurrentTrackerState, UT_VERSION
 from .TrackerCore import TrackerCore
 from collections import Counter, defaultdict
 from MultiServer import mark_raw
-from NetUtils import NetworkItem, JSONMessagePart
+from NetUtils import NetworkItem, JSONMessagePart, HintStatus
 
 try:
     from Utils import gui_enabled
@@ -1199,16 +1200,35 @@ class TrackerGameContext(CommonContext):
             base_title = f"Tracker {UT_VERSION}{' Addons ' if UT_ADDONS_VERSION else ' '}{UT_ADDONS_VERSION if UT_ADDONS_VERSION else '' } for {apname} version"  # core appends ap version so this works
 
             def build(self):
+                def check_logic(data) -> tuple[bool, bool]:
+                    ctx = ui.get_running_app().ctx
+                    found = data["status"]["hint"]["status"] == HintStatus.HINT_FOUND
+                    in_logic = data["status"]["hint"]["location"] in ctx.tracker_core.locations_available
+                    return found, in_logic
+
+                def get_logic_string(found: bool, in_logic: bool) -> str:
+                    return "Found" if found else "In Logic" if in_logic else "Not Found"
+
+                def sort_hint_by_logic(data: dict) -> int:
+                    found, in_logic = check_logic(data)
+                    if found:
+                        return 2
+                    if in_logic:
+                        return 0
+                    return 1
+
                 class TrackerHintLabel(HintLabel):
                     logic_text = StringProperty("")
 
                     def __init__(self, *args, **kwargs):
                         super().__init__(*args, **kwargs)
                         logic = TooltipLabel(
-                            sort_key="finding",  # is lying to computer and player but fixing it will need core changes
+                            sort_key="in_logic",
                             text="", halign='center', valign='center', pos_hint={"center_y": 0.5},
                             )
                         self.add_widget(logic)
+                        from kivy.weakproxy import WeakProxy
+                        self.ids["in_logic"] = WeakProxy(logic)
 
                         def set_text(_, value):
                             logic.text = value
@@ -1220,23 +1240,12 @@ class TrackerGameContext(CommonContext):
                             self.logic_text = "[u]In Logic[/u]"
                             return
                         ctx = ui.get_running_app().ctx
-                        if "status" in data:
-                            loc = data["status"]["hint"]["location"]
-                            from NetUtils import HintStatus
-                            found = data["status"]["hint"]["status"] == HintStatus.HINT_FOUND
-                        else:
-                            prefix = len("[color=00FF7F]")
-                            suffix = len("[/color]")
-                            loc_name = data["location"]["text"][prefix:-1*suffix]
-                            loc = AutoWorld.AutoWorldRegister.world_types[ctx.game].location_name_to_id.get(loc_name)
-                            found = "Not Found" not in data["found"]["text"]
+                        found, in_logic = check_logic(data)
 
-                        in_logic = loc in ctx.tracker_core.locations_available
                         self.logic_text = rv.parser.handle_node({
-                            "type": "color", "color": "green" if found else
-                            "orange" if in_logic else "red",
-                            "text": "Found" if found else "In Logic" if in_logic
-                            else "Not Found"})
+                            "type": "color",
+                            "color": "green" if found else "orange" if in_logic else "red",
+                            "text": get_logic_string(found, in_logic)})
 
                 def kv_post(self, base_widget):
                     self.viewclass = TrackerHintLabel
@@ -1244,6 +1253,17 @@ class TrackerGameContext(CommonContext):
 
                 container = super().build()
                 self.ctx.build_gui(self)
+
+                from kvui import ColumnSorter, ColumnFilter
+                self.hint_log.column_sorters.append(ColumnSorter(
+                    "in_logic",
+                    sort_hint_by_logic,
+                    False
+                ))
+                hint_filt = ColumnFilter("in_logic",
+                                         lambda element: get_logic_string(*check_logic(element)))
+                hint_filt.option_list = {"Found", "In Logic", "Not Found"}
+                self.hint_log.column_filters.append(hint_filt)
 
                 return container
 


### PR DESCRIPTION
## What is this fixing or adding?
Update Universal Tracker to use ColumnSorter / ColumnFilter for the custom `In Logic` column, allowing it to be sorted by and filtered by like the other columns.

NOTE: This is built off of #33 and should probably be merged after that one separately? It'll probably need cleanup after #33 is merged, I can handle that if needed. Only the last commit `UT: Update Hint tab to use ColumnSorter / ColumnFilter for 'In Logic'` is what this PR is actually about, the rest is all #33.

## How was this tested?
Tracked a stardew game, hinted several things such that I had some hinted things found, in logic, and not found, and played with the sorting/filters to ensure they worked correctly.

## If this makes graphical changes, please attach screenshots.
<img width="799" height="327" alt="image" src="https://github.com/user-attachments/assets/85c01027-5c07-4197-a489-ae704a2dfe44" />
