### PR TITLE
Allow 'New Hint' on hint tab to use Groups + Location Hints

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -478,7 +478,57 @@ class MarkupDropdownTextItem(MDDropdownTextItem):
     # Create new TextItems as needed
 
 
-class MarkupDropdown(MDDropdownMenu):
+class FixedMDDropdownMenu(MDDropdownMenu):
+    def check_ver_growth(self) -> None:
+        """
+        Checks whether the height of the lower/upper borders of the menu
+        exceeds the limits borders of the parent window.
+        """
+        # The MDDropdownMenu version handles the case of both up and down being bad poorly.
+
+        bad_down = self.target_height > self._start_coords[1] - self.border_margin
+        bad_up = self._start_coords[1] > Window.height - self._start_coords[1]
+        if bad_down and bad_up:
+            self.ver_growth = None  # try to stay centered if both ends are bad
+        elif bad_down:
+            self.ver_growth = "up"
+        elif bad_up:
+            self.ver_growth = "down"
+
+    def check_hor_growth(self) -> None:
+        """
+        Checks whether the width of the left/right menu borders exceeds the
+        boundaries of the parent window.
+        """
+        # The MDDropdownMenu version handles the case of both left and right being bad poorly.
+
+        bad_right = Window.width - (self._start_coords[0] + self.border_margin) <= self.width
+        bad_left = self.width >= self._start_coords[0] + self.border_margin
+        if bad_right and bad_left:
+            self.hor_growth = None  # try to stay centered if both ends are bad
+        elif bad_right:
+            self.hor_growth = "left"
+        elif bad_left:
+            self.hor_growth = "right"
+
+    def get_target_pos(self) -> tuple[float, float]:
+        # The MDDropdownMenu version doesn't handle a centered axis properly (it treats centered as down/right instead)
+        self._tar_x, self._tar_y = self._start_coords
+
+        if self.ver_growth == "up":
+            self._tar_y = self._start_coords[1] + self.height
+        elif not self.ver_growth:
+            self._tar_y = self._start_coords[1] + self.height / 2
+
+        if self.hor_growth == "left":
+            self._tar_x = self._start_coords[0] - self.width
+        elif not self.hor_growth:
+            self._tar_x = self._start_coords[0] - self.width / 2
+
+        return self._tar_x, self._tar_y
+
+
+class MarkupDropdown(FixedMDDropdownMenu):
     def on_items(self, instance, value: list) -> None:
         """
         The method sets the class that will be used to create the menu item.
@@ -553,16 +603,19 @@ class MarkupDropdown(MDDropdownMenu):
 
 class AutocompleteHintInput(ResizableTextField):
     min_chars = NumericProperty(3)
+    show_groups = BooleanProperty(False)
+    show_locations = BooleanProperty(False)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.dropdown = MarkupDropdown(caller=self, position="bottom", border_margin=dp(2), width=self.width)
+        self.dropdown = MarkupDropdown(caller=self, border_margin=dp(2), width=self.width)
         self.bind(on_text_validate=self.on_message)
         self.bind(width=lambda instance, x: setattr(self.dropdown, "width", x))
 
     def on_message(self, instance):
-        MDApp.get_running_app().commandprocessor("!hint "+instance.text)
+        pref = "!hint_location " if self.show_locations else "!hint "
+        MDApp.get_running_app().commandprocessor(pref + instance.text)
 
     def on_text(self, instance, value):
         if len(value) >= self.min_chars:
@@ -570,30 +623,46 @@ class AutocompleteHintInput(ResizableTextField):
             ctx: context_type = MDApp.get_running_app().ctx
             if not ctx.game:
                 return
-            item_names = ctx.item_names._game_store[ctx.game].values()
+            if self.show_groups:
+                lookup = (Utils.persistent_load()
+                          .get("groups_by_checksum", {})
+                          .get(ctx.checksums[ctx.game], {})
+                          .get(ctx.game, {}))
+                if self.show_locations:
+                    autofill_names = lookup.get("location_name_groups", {}).keys()
+                else:
+                    autofill_names = lookup.get("item_name_groups", {}).keys()
+            else:
+                if self.show_locations:
+                    # noinspection PyProtectedMember
+                    autofill_names = ctx.location_names._game_store[ctx.game].values()
+                else:
+                    # noinspection PyProtectedMember
+                    autofill_names = ctx.item_names._game_store[ctx.game].values()
 
-            def on_press(text):
-                split_text = MarkupLabel(text=text).markup
+            def on_press(txt):
+                split_text = MarkupLabel(text=txt).markup
                 self.set_text(self, "".join(text_frag for text_frag in split_text
                                             if not text_frag.startswith("[")))
                 self.dropdown.dismiss()
                 self.focus = True
 
             lowered = value.lower()
-            for item_name in item_names:
+            for name in autofill_names:
                 try:
-                    index = item_name.lower().index(lowered)
+                    index = name.lower().index(lowered)
                 except ValueError:
                     pass  # substring not found
                 else:
-                    text = escape_markup(item_name)
+                    text = escape_markup(name)
                     text = text[:index] + "[b]" + text[index:index+len(value)]+"[/b]"+text[index+len(value):]
                     self.dropdown.items.append({
                         "text": text,
                         "on_release": lambda txt=text: on_press(txt),
-                        "markup": True
+                        "markup": True,
+                        "padding": (15, 0),
                     })
-            if not self.dropdown.parent:
+            if not self.dropdown.parent and self.dropdown.items:
                 self.dropdown.open()
         else:
             self.dropdown.dismiss()
@@ -1206,7 +1275,24 @@ class HintLayout(MDBoxLayout):
         boxlayout = MDBoxLayout(orientation="horizontal", size_hint_y=None, height=dp(40))
         boxlayout.add_widget(MDLabel(text="New Hint:", size_hint_x=None, size_hint_y=None,
                                      height=dp(40), width=dp(75), halign="center", valign="center"))
-        boxlayout.add_widget(AutocompleteHintInput())
+
+        hint_autocomplete = AutocompleteHintInput()
+        boxlayout.add_widget(hint_autocomplete)
+
+        def toggle_groups(instance: Widget, value: str):
+            hint_autocomplete.show_groups = value == "down"
+
+        def toggle_locations(instance: Widget, value: str):
+            hint_autocomplete.show_locations = value == "down"
+
+        groups_toggle = ToggleButton(MDButtonText(text="Groups"), size_hint_x=None, size_hint_y=None)
+        groups_toggle.bind(state=toggle_groups)
+        boxlayout.add_widget(groups_toggle)
+
+        locations_toggle = ToggleButton(MDButtonText(text="Locations"), size_hint_x=None, size_hint_y=None)
+        locations_toggle.bind(state=toggle_locations)
+        boxlayout.add_widget(locations_toggle)
+
         self.add_widget(boxlayout)
 
     def fix_heights(self):
@@ -1214,6 +1300,7 @@ class HintLayout(MDBoxLayout):
             fix_func = getattr(child, "fix_heights", None)
             if fix_func:
                 fix_func()
+
 
 status_names: typing.Dict[HintStatus, str] = {
     HintStatus.HINT_FOUND: "Found",


### PR DESCRIPTION
## What is this fixing or adding?
The `New Hint:` option on the Hint Tab allowed typing an item name and creating a hint easily - item names would autofill, pressing enter runs `!hint [text]`. It did have some missing things though: item groups, while they can be hinted this way, do not appear in the autofill; and location hints are entirely unable to be created with this method.

This PR adds:
- `Groups` toggle (if on, item/location Group names will be used for the autofill)
- `Locations` toggle (if on, hints are for locations instead of items; autofill uses location/location groups instead of item/item groups, and runs `!hint_location [text]` on pressing enter instead of `!hint [text]`
- Cleaned up some issues I ended up having with the DropDown widget positionally, it now properly opens upwards centered on the input box. I . . . really am confused by this, but as far as I can see, these dropdowns were just totally busted in how they positioned themselves. They try to use `position="bottom"`, but . . . I cannot make any sense of the code related to that value, it looks to me like it's just buggy/broken (and it's kivymd code, not code in our repo...). I fixed this by just . . . NOT doing that (omitting position as an arg uses `position="auto"` which looks mostly fine. Except, under auto positioning, the entire dropdown was actually going completely OFFSCREEN! Auto was not *centering* it horizontally, and this lead to bad interactions with the growth direction code. So, I subclassed the dropdown menu and overrode some functions to give a centered default, and handle centering in the growth code as well, allowing this dropdown to look nice.
    - Except, it kinda half-covers the text input box while you're typing in it. :sigh: I am not sure how easy this part is to fix without overriding yet more shit and bleh. This issue was already present before as well though, so, not a new one, just a small thing that I failed to fix here. This happens because the default-bound position is the center of the 'caller' widget, so we would need to offset that start so it's the center-top instead of the center-center. I could probably *hack* something to get this alignment fixed, but I wouldn't feel good about it- a more proper fix I'm unsure of what design would be best. Would we want a, like, anchor corner arg, to choose a corner of the caller to anchor to? or a position arg to directly set the starting position? Either way, this probably involves overriding `set_menu_properties` for the dropdown subclass.

## How was this tested?
Toggled the new toggles on/off and typed various things into the text field to ensure the auto-complete worked correctly for each mode.

## If this makes graphical changes, please attach screenshots.

https://github.com/user-attachments/assets/ac5098de-797e-4314-b4b5-4452ef6eb1ee

