### PR TITLE
Core: DataStorage keys prefixed with `_admin_` require admin access to modify

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2347,6 +2347,10 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                                               "text": 'Set', "original_cmd": cmd}])
                 return
+            if args["key"].startswith("_admin_") and not client.messageprocessor.is_authenticated():
+                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', 'type': 'permission',
+                                              'text': 'Modifying an "_admin_" key requires admin authentication first', 'original_cmd': cmd}])
+                return
             args["cmd"] = "SetReply"
             value = ctx.stored_data.get(args["key"], args.get("default", 0))
             args["original_value"] = copy.copy(value)

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -244,6 +244,7 @@ Sent to clients if the server caught a problem with a packet. This only occurs f
 | ---- | ----- |
 | cmd | `cmd` argument of the faulty packet that could not be parsed correctly. |
 | arguments | Arguments of the faulty packet which were not correct. |
+| permission | Client was not authenticated as admin, and command required admin permission. |
 
 ### Retrieved
 Sent to clients as a response the a [Get](#Get) package.
@@ -450,6 +451,7 @@ Some special keys exist with specific return data, all of them have the prefix `
 ### Set
 Used to write data to the server's data storage, that data can then be shared across worlds or just saved for later. Values for keys in the data storage can be retrieved with a [Get](#Get) package, or monitored with a [SetNotify](#SetNotify) package.
 Keys that start with `_read_` cannot be set.
+Keys that start with `_admin_` require the client to be logged in as a room admin via `!admin login` before modifying.
 #### Arguments
 | Name       | Type                                                  | Notes                                                                                                                  |
 |------------|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
see https://github.com/ArchipelagoMW/Archipelago/pull/6172

TL;DR datastorage keys that start with `_admin_` will return a permission error if you try to modify them, unless you are logged in via `!admin login` first. This allows datastorage values that can be READ by any client, but only WRITTEN by someone with host priviledges- perfect for admin room settings like APSudoku uses. (APSudoku v4.0.0 was just released, and now uses datastorage keys with this prefix, so will immediately be affected by this once merged)